### PR TITLE
Add Button Trigger Confirmation Dialog

### DIFF
--- a/src/main/java/se/bjurr/prnfb/http/HttpResponse.java
+++ b/src/main/java/se/bjurr/prnfb/http/HttpResponse.java
@@ -1,0 +1,19 @@
+package se.bjurr.prnfb.http;
+
+public class HttpResponse {
+	public HttpResponse(int status, String content) {
+		this.status = status;
+		this.content = content;
+	}
+	
+	private int status;
+	private String content;
+	
+	public int getStatus() {
+		return status;
+	}
+	
+	public String getContent() {
+		return content;
+	}
+}

--- a/src/main/java/se/bjurr/prnfb/http/Invoker.java
+++ b/src/main/java/se/bjurr/prnfb/http/Invoker.java
@@ -1,5 +1,5 @@
 package se.bjurr.prnfb.http;
 
 public interface Invoker {
- void invoke(UrlInvoker urlInvoker);
+	HttpResponse invoke(UrlInvoker urlInvoker);
 }

--- a/src/main/java/se/bjurr/prnfb/listener/PrnfbPullRequestEventListener.java
+++ b/src/main/java/se/bjurr/prnfb/listener/PrnfbPullRequestEventListener.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 import org.slf4j.Logger;
 
 import se.bjurr.prnfb.http.ClientKeyStore;
+import se.bjurr.prnfb.http.HttpResponse;
 import se.bjurr.prnfb.http.Invoker;
 import se.bjurr.prnfb.http.UrlInvoker;
 import se.bjurr.prnfb.service.PrnfbRenderer;
@@ -127,11 +128,11 @@ public class PrnfbPullRequestEventListener {
   return TRUE;
  }
 
- public void notify(final PrnfbNotification notification, PrnfbPullRequestAction pullRequestAction,
+ public HttpResponse notify(final PrnfbNotification notification, PrnfbPullRequestAction pullRequestAction,
    PullRequest pullRequest, PrnfbRenderer renderer, ClientKeyStore clientKeyStore, Boolean shouldAcceptAnyCertificate) {
   if (!isNotificationTriggeredByAction(notification, pullRequestAction, renderer, pullRequest, clientKeyStore,
     shouldAcceptAnyCertificate)) {
-   return;
+   return null;
   }
 
   Optional<String> postContent = absent();
@@ -155,7 +156,7 @@ public class PrnfbPullRequestEventListener {
      .withHeader(header.getName(),
        renderer.render(header.getValue(), FALSE, clientKeyStore, shouldAcceptAnyCertificate));
   }
-  createInvoker().invoke(urlInvoker//
+  return createInvoker().invoke(urlInvoker//
     .withProxyServer(notification.getProxyServer()) //
     .withProxyPort(notification.getProxyPort())//
     .withProxyUser(notification.getProxyUser())//
@@ -219,8 +220,8 @@ public class PrnfbPullRequestEventListener {
   }
   return new Invoker() {
    @Override
-   public void invoke(UrlInvoker urlInvoker) {
-    urlInvoker.invoke();
+   public HttpResponse invoke(UrlInvoker urlInvoker) {
+    return urlInvoker.invoke();
    }
   };
  }

--- a/src/main/java/se/bjurr/prnfb/presentation/ButtonServlet.java
+++ b/src/main/java/se/bjurr/prnfb/presentation/ButtonServlet.java
@@ -5,12 +5,14 @@ import static javax.ws.rs.core.Response.ok;
 import static javax.ws.rs.core.Response.status;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
+import static se.bjurr.prnfb.transformer.ButtonTransformer.toTriggerResultDto;
 import static se.bjurr.prnfb.transformer.ButtonTransformer.toButtonDto;
 import static se.bjurr.prnfb.transformer.ButtonTransformer.toButtonDtoList;
 import static se.bjurr.prnfb.transformer.ButtonTransformer.toPrnfbButton;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import javax.ws.rs.Consumes;
@@ -22,7 +24,9 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
+import se.bjurr.prnfb.http.HttpResponse;
 import se.bjurr.prnfb.presentation.dto.ButtonDTO;
+import se.bjurr.prnfb.presentation.dto.TriggerResultDTO;
 import se.bjurr.prnfb.service.ButtonsService;
 import se.bjurr.prnfb.service.SettingsService;
 import se.bjurr.prnfb.service.UserCheckService;
@@ -148,9 +152,10 @@ public class ButtonServlet {
   if (!this.userCheckService.isAllowedUseButton(button)) {
    return status(UNAUTHORIZED).build();
   }
-  this.buttonsService.handlePressed(repositoryId, pullRequestId, buttionUuid);
+  Map<String, HttpResponse> results = this.buttonsService.handlePressed(repositoryId, pullRequestId, buttionUuid);
 
-  return status(OK).build();
+  TriggerResultDTO dto = toTriggerResultDto(button, results);
+  return ok(dto, APPLICATION_JSON).build();
  }
 
 }

--- a/src/main/java/se/bjurr/prnfb/presentation/dto/ButtonDTO.java
+++ b/src/main/java/se/bjurr/prnfb/presentation/dto/ButtonDTO.java
@@ -18,6 +18,7 @@ public class ButtonDTO implements Comparable<ButtonDTO> {
  private String name;
  private String projectKey;
  private String repositorySlug;
+ private String confirmation;
  private USER_LEVEL userLevel;
  private UUID uuid;
 
@@ -62,6 +63,13 @@ public class ButtonDTO implements Comparable<ButtonDTO> {
   if (this.userLevel != other.userLevel) {
    return false;
   }
+  if (this.confirmation == null) {
+   if (other.confirmation != null) {
+    return false;
+   }
+  } else if (!this.confirmation.equals(other.confirmation)) {
+   return false;
+  }
   if (this.uuid == null) {
    if (other.uuid != null) {
     return false;
@@ -88,6 +96,10 @@ public class ButtonDTO implements Comparable<ButtonDTO> {
   return this.userLevel;
  }
 
+ public String getConfirmation() {
+  return this.confirmation;
+ }
+
  public UUID getUuid() {
   return this.uuid;
  }
@@ -105,6 +117,7 @@ public class ButtonDTO implements Comparable<ButtonDTO> {
   result = prime * result + ((this.name == null) ? 0 : this.name.hashCode());
   result = prime * result + ((this.userLevel == null) ? 0 : this.userLevel.hashCode());
   result = prime * result + ((this.uuid == null) ? 0 : this.uuid.hashCode());
+  result = prime * result + ((this.confirmation == null) ? 0 : this.confirmation.hashCode());
   return result;
  }
 
@@ -128,10 +141,22 @@ public class ButtonDTO implements Comparable<ButtonDTO> {
   this.uuid = uuid;
  }
 
+ public void setConfirmation(String confirmation) {
+  if (confirmation == null) {
+    this.confirmation = "off";
+  }
+  else if (confirmation.equalsIgnoreCase("on")) {
+    this.confirmation = "on";
+  }
+  else {
+    this.confirmation = "off";
+  }
+ }
+
  @Override
  public String toString() {
   return "ButtonDTO [name=" + this.name + ", userLevel=" + this.userLevel + ", uuid=" + this.uuid + ", repositorySlug="
-    + this.repositorySlug + ", projectKey=" + this.projectKey + "]";
+    + this.repositorySlug + ", projectKey=" + this.projectKey + ", confirmation=" + this.confirmation + "]";
  }
 
 }

--- a/src/main/java/se/bjurr/prnfb/presentation/dto/TriggerResultDTO.java
+++ b/src/main/java/se/bjurr/prnfb/presentation/dto/TriggerResultDTO.java
@@ -1,0 +1,92 @@
+package se.bjurr.prnfb.presentation.dto;
+
+import static javax.xml.bind.annotation.XmlAccessType.FIELD;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import com.google.common.base.Optional;
+
+import se.bjurr.prnfb.http.HttpResponse;
+
+@XmlRootElement
+@XmlAccessorType(FIELD)
+public class TriggerResultDTO implements Comparable<TriggerResultDTO> {
+
+ private String name;
+ private Map<String, Map<String, Object>> results;
+
+ @Override
+ public int compareTo(TriggerResultDTO o) {
+  return this.name.compareTo(o.name);
+ }
+
+ @Override
+ public boolean equals(Object obj) {
+  if (this == obj) {
+   return true;
+  }
+  if (obj == null) {
+   return false;
+  }
+  if (getClass() != obj.getClass()) {
+   return false;
+  }
+  TriggerResultDTO other = (TriggerResultDTO) obj;
+  if (this.results == null) {
+   if (other.results != null) {
+    return false;
+   }
+  } else if (!this.results.equals(other.results)) {
+   return false;
+  }
+  if (this.name == null) {
+   if (other.name != null) {
+    return false;
+   }
+  } else if (!this.name.equals(other.name)) {
+   return false;
+  }
+  return true;
+ }
+
+ public String getName() {
+  return this.name;
+ }
+
+ public Optional<Map<String, Map<String, Object>>> getResults() {
+  return Optional.fromNullable(this.results);
+ }
+
+ @Override
+ public int hashCode() {
+  final int prime = 31;
+  int result = 1;
+  result = prime * result + ((this.results == null) ? 0 : this.results.hashCode());
+  result = prime * result + ((this.name == null) ? 0 : this.name.hashCode());
+  return result;
+ }
+
+ public void setName(String name) {
+  this.name = name;
+ }
+
+ public void setResults(Map<String, HttpResponse> results) {
+  this.results = new HashMap<String, Map<String, Object>>();
+  for(String key : results.keySet()) {
+	  Map<String, Object> data = new HashMap<String, Object>();
+	  data.put("status", results.get(key).getStatus());
+	  data.put("response", results.get(key).getContent());
+	  this.results.put(key, data);
+  }
+ }
+
+ @Override
+ public String toString() {
+  return "TriggerResultDTO [name=" + this.name + ", results=" + this.results + "]";
+ }
+
+}

--- a/src/main/java/se/bjurr/prnfb/service/PrnfbVariable.java
+++ b/src/main/java/se/bjurr/prnfb/service/PrnfbVariable.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 
 import se.bjurr.prnfb.http.ClientKeyStore;
+import se.bjurr.prnfb.http.HttpResponse;
 import se.bjurr.prnfb.http.Invoker;
 import se.bjurr.prnfb.http.UrlInvoker;
 import se.bjurr.prnfb.listener.PrnfbPullRequestAction;
@@ -87,7 +88,7 @@ public enum PrnfbVariable {
      .shouldAcceptAnyCertificate(shouldAcceptAnyCertificate);
    createInvoker()//
      .invoke(urlInvoker);
-   String rawResponse = urlInvoker.getResponseString().trim();
+   String rawResponse = urlInvoker.getResponse().getContent().trim();
    if (prnfbNotification.getInjectionUrlRegexp().isPresent()) {
     Matcher m = compile(prnfbNotification.getInjectionUrlRegexp().get()).matcher(rawResponse);
     if (!m.find()) {
@@ -490,8 +491,8 @@ public enum PrnfbVariable {
 
  private static Invoker mockedInvoker = new Invoker() {
   @Override
-  public void invoke(UrlInvoker urlInvoker) {
-   urlInvoker.invoke();
+  public HttpResponse invoke(UrlInvoker urlInvoker) {
+   return urlInvoker.invoke();
   }
  };
 
@@ -531,8 +532,8 @@ public enum PrnfbVariable {
   }
   return new Invoker() {
    @Override
-   public void invoke(UrlInvoker urlInvoker) {
-    urlInvoker.invoke();
+   public HttpResponse invoke(UrlInvoker urlInvoker) {
+    return urlInvoker.invoke();
    }
   };
  }

--- a/src/main/java/se/bjurr/prnfb/service/SettingsService.java
+++ b/src/main/java/se/bjurr/prnfb/service/SettingsService.java
@@ -315,7 +315,7 @@ public class SettingsService {
    if (oldButton.getVisibility() == BUTTON_VISIBILITY.EVERYONE) {
     userLevel = USER_LEVEL.EVERYONE;
    }
-   newButtons.add(new PrnfbButton(UUID.randomUUID(), oldButton.getTitle(), userLevel, null, null));
+   newButtons.add(new PrnfbButton(UUID.randomUUID(), oldButton.getTitle(), userLevel, "off", null, null));
   }
 
   List<PrnfbNotification> newNotifications = newArrayList();

--- a/src/main/java/se/bjurr/prnfb/settings/PrnfbButton.java
+++ b/src/main/java/se/bjurr/prnfb/settings/PrnfbButton.java
@@ -14,13 +14,15 @@ public class PrnfbButton implements HasUuid {
  private final String name;
  private final String projectKey;
  private final String repositorySlug;
+ private final String confirmation;
  private final USER_LEVEL userLevel;
  private final UUID uuid;
 
- public PrnfbButton(UUID uuid, String name, USER_LEVEL userLevel, String projectKey, String repositorySlug) {
+ public PrnfbButton(UUID uuid, String name, USER_LEVEL userLevel, String confirmation, String projectKey, String repositorySlug) {
   this.uuid = firstNonNull(uuid, randomUUID());
   this.name = name;
   this.userLevel = userLevel;
+  this.confirmation = confirmation;
   this.repositorySlug = emptyToNull(repositorySlug);
   this.projectKey = emptyToNull(projectKey);
  }
@@ -68,6 +70,13 @@ public class PrnfbButton implements HasUuid {
   } else if (!this.uuid.equals(other.uuid)) {
    return false;
   }
+  if (this.confirmation == null) {
+	   if (other.confirmation != null) {
+	    return false;
+	   }
+	  } else if (!this.confirmation.equals(other.confirmation)) {
+	   return false;
+	   }
   return true;
  }
 
@@ -87,6 +96,10 @@ public class PrnfbButton implements HasUuid {
   return this.userLevel;
  }
 
+ public String getConfirmation() {
+  return this.confirmation;
+ }
+
  @Override
  public UUID getUuid() {
   return this.uuid;
@@ -101,13 +114,14 @@ public class PrnfbButton implements HasUuid {
   result = prime * result + ((this.name == null) ? 0 : this.name.hashCode());
   result = prime * result + ((this.userLevel == null) ? 0 : this.userLevel.hashCode());
   result = prime * result + ((this.uuid == null) ? 0 : this.uuid.hashCode());
+  result = prime * result + ((this.confirmation == null) ? 0 : this.confirmation.hashCode());
   return result;
  }
 
  @Override
  public String toString() {
   return "PrnfbButton [projectKey=" + this.projectKey + ", repositorySlug=" + this.repositorySlug + ", name="
-    + this.name + ", userLevel=" + this.userLevel + ", uuid=" + this.uuid + "]";
+    + this.name + ", userLevel=" + this.userLevel + ", uuid=" + this.uuid + ", confirmation=" + this.confirmation + "]";
  }
 
 }

--- a/src/main/java/se/bjurr/prnfb/transformer/ButtonTransformer.java
+++ b/src/main/java/se/bjurr/prnfb/transformer/ButtonTransformer.java
@@ -3,12 +3,23 @@ package se.bjurr.prnfb.transformer;
 import static com.google.common.collect.Lists.newArrayList;
 
 import java.util.List;
+import java.util.Map;
 
+import se.bjurr.prnfb.http.HttpResponse;
 import se.bjurr.prnfb.presentation.dto.ButtonDTO;
+import se.bjurr.prnfb.presentation.dto.TriggerResultDTO;
 import se.bjurr.prnfb.settings.PrnfbButton;
 
 public class ButtonTransformer {
 
+	
+ public static TriggerResultDTO toTriggerResultDto(PrnfbButton from, Map<String, HttpResponse> results) {
+  TriggerResultDTO to = new TriggerResultDTO();
+  to.setName(from.getName());
+  to.setResults(results);
+  return to;
+}
+	
  public static ButtonDTO toButtonDto(PrnfbButton from) {
   ButtonDTO to = new ButtonDTO();
   to.setName(from.getName());
@@ -16,6 +27,7 @@ public class ButtonTransformer {
   to.setUuid(from.getUuid());
   to.setProjectKey(from.getProjectKey().orNull());
   to.setRepositorySlug(from.getRepositorySlug().orNull());
+  to.setConfirmation(from.getConfirmation());
   return to;
  }
 
@@ -32,6 +44,7 @@ public class ButtonTransformer {
     buttonDto.getUUID(), //
     buttonDto.getName(), //
     buttonDto.getUserLevel(),//
+    buttonDto.getConfirmation(),//
     buttonDto.getProjectKey().orNull(),//
     buttonDto.getRepositorySlug().orNull());//
  }

--- a/src/main/resources/admin.vm
+++ b/src/main/resources/admin.vm
@@ -19,6 +19,8 @@
  <!-- //-->
  $webResourceManager.requireResource("com.atlassian.auiplugin:aui-select")
  <!-- //-->
+ $webResourceManager.requireResource("com.atlassian.auiplugin:aui-toggle")
+ <!-- //-->
  $webResourceManager.requireResource("com.atlassian.auiplugin:aui-experimental-expander")
 </head>
 
@@ -229,6 +231,12 @@
      <label>Title </label>
      <input class="text long-field" type="text" name="name">
      <div class="description">The title of the button.</div>
+    </div>
+    
+    <div class="field-group">
+     <aui-toggle id="confirmation" label="Confirmation Dialog" name="confirmation"></aui-toggle>
+     <label>Confirmation </label>
+     <div class="description">Whether to show a confirmation dialog.</div>
     </div>
 
     <div class="aui-buttons">

--- a/src/main/resources/pr-triggerbutton.js
+++ b/src/main/resources/pr-triggerbutton.js
@@ -12,6 +12,58 @@ define('plugin/prnfb/pr-triggerbutton', [
  var buttonTemplate = function(name) {
   return $('<li><button class="aui-button aui-button-link" role="menuitem">' + name + '</button></li>'); 
  }
+ var dialogTemplate = function(name, content) {
+   return '<section role="dialog" id="confirm-dialog" class="aui-layer aui-dialog2 aui-dialog2-medium" data-aui-remove-on-hide="true" aria-hidden="true">'
+      + '    <!-- Dialog header -->'
+      + '    <header class="aui-dialog2-header">'
+      + '        <h2 class="aui-dialog2-header-main">' + name + ' Confirmation</h2>'
+      + '        <!-- Close icon -->'
+      + '        <a class="aui-dialog2-header-close">'
+      + '            <span class="aui-icon aui-icon-small aui-iconfont-close-dialog">Close</span>'
+      + '        </a>'
+      + '    </header>'
+      + '    <!-- Main dialog content -->'
+      + '    <div class="aui-dialog2-content">'
+      + '    ' + content
+      + '    </div>'
+      + '    <!-- Dialog footer -->'
+      + '    <footer class="aui-dialog2-footer">'
+      + '        <!-- Actions to render on the right of the footer -->'
+      + '        <div class="aui-dialog2-footer-actions">'
+      + '            <button id="dialog-close-button" class="aui-button aui-button-link">Close</button>'
+      + '        </div>'
+      + '    </footer>'
+      + '</section>'
+ }
+ 
+ var dialogContentTemplate = function(response) {
+  var successTriggers = [];
+  var failTriggers = [];
+  if (response) {
+   for(var key in response.results) {
+    if (response.results.hasOwnProperty(key)) {
+     var val = response.results[key];
+     if (val.status >= 200 && val.status <= 299) {
+       successTriggers.push("<li>"+key+"</li>");
+     } else {
+       failTriggers.push("<li>"+key+"</li>");
+     }
+    }
+   }
+  } 
+  result = "";
+  if (successTriggers.length > 0) {
+   result += "<p>Succeeded Triggers:<ul>" + successTriggers.join("") + "</ul></p>";
+  }
+  if (failTriggers.length > 0) {
+   result += "<p>Failed Triggers:<ul>" + failTriggers.join("") + "</ul></p>";
+  }
+  if ((successTriggers.length + failTriggers.length) == 0) {
+   result += "<p>No triggers were invoked</p>";
+  }
+  return result;
+ }
+ 
  if ($buttonArea.length === 0) {
   //Before 4.4.0
   $buttonArea = $(".triggerManualNotification").parent();
@@ -32,18 +84,46 @@ define('plugin/prnfb/pr-triggerbutton', [
      $this.attr("aria-disabled", "true");
      $this.prepend(waiting);
 
-     $.post(buttonsAdminUrl + '/' + item.uuid + '/press/repository/' + pageState.getRepository().id + '/pullrequest/' + pageState.getPullRequest().id, function() {
-      setTimeout(function() {
-       $this.removeAttr("disabled");
-       $this.removeAttr("aria-disabled");
-       $this.find("span").remove();
-      }, 500);
+     $.ajax({
+      "type": "POST",
+      "url": buttonsAdminUrl + '/' + item.uuid + '/press/repository/' + pageState.getRepository().id + '/pullrequest/' + pageState.getPullRequest().id,
+      "success": function(content) {
+        setTimeout(function() {
+         $this.removeAttr("disabled");
+         $this.removeAttr("aria-disabled");
+         $this.find("span").remove();
+         
+         if (item.confirmation == "on") {
+          var $dialog = $(dialogTemplate(item.name, dialogContentTemplate(content)));
+          $dialog.appendTo($("body"));
+          
+          var dialogRef = AJS.dialog2($dialog);
+          AJS.$("#dialog-close-button").click(function(e) {
+              e.preventDefault();
+              dialogRef.hide();
+          });
+          dialogRef.show();
+         }
+        }, 500);
+      },
+      "error": function(content) {
+        if (item.confirmation == "on") {
+         var $dialog = $(dialogTemplate(item.name, "<p>There was an error triggering the notification</p>"));
+         $dialog.appendTo($("body"));
+         
+         var dialogRef = AJS.dialog2($dialog);
+         AJS.$("#dialog-close-button").click(function(e) {
+             e.preventDefault();
+             dialogRef.hide();
+         });
+         dialogRef.show();
+       }
+      }
      });
-    });
 
+    });
     $buttonArea.append($buttonDropdownItem);
    });
-
   });
  }
 

--- a/src/test/java/se/bjurr/prnfb/http/UrlInvokerTest.java
+++ b/src/test/java/se/bjurr/prnfb/http/UrlInvokerTest.java
@@ -31,9 +31,9 @@ public class UrlInvokerTest {
  public void before() {
   this.urlInvoker = new UrlInvoker() {
    @Override
-   String doInvoke(HttpRequestBase httpRequest, HttpClientBuilder builder) {
+   HttpResponse doInvoke(HttpRequestBase httpRequest, HttpClientBuilder builder) {
     UrlInvokerTest.this.httpRequestBase = httpRequest;
-    return "";
+    return new HttpResponse(200, "");
    }
   }//
   .withUrlParam("http://url.com/");

--- a/src/test/java/se/bjurr/prnfb/listener/PrnfbPullRequestEventListenerTest.java
+++ b/src/test/java/se/bjurr/prnfb/listener/PrnfbPullRequestEventListenerTest.java
@@ -31,6 +31,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import se.bjurr.prnfb.http.ClientKeyStore;
+import se.bjurr.prnfb.http.HttpResponse;
 import se.bjurr.prnfb.http.Invoker;
 import se.bjurr.prnfb.http.UrlInvoker;
 import se.bjurr.prnfb.service.PrnfbRenderer;
@@ -88,8 +89,11 @@ public class PrnfbPullRequestEventListenerTest {
     this.executorService, this.settingsService);
   setInvoker(new Invoker() {
    @Override
-   public void invoke(UrlInvoker urlInvoker) {
+   public HttpResponse invoke(UrlInvoker urlInvoker) {
+    HttpResponse response = new HttpResponse(200, "");
+    urlInvoker.setResponse(response);
     PrnfbPullRequestEventListenerTest.this.invokedUrls.add(urlInvoker);
+    return response;
    }
   });
 

--- a/src/test/java/se/bjurr/prnfb/presentation/ButtonServletTest.java
+++ b/src/test/java/se/bjurr/prnfb/presentation/ButtonServletTest.java
@@ -183,13 +183,14 @@ public class ButtonServletTest {
   button.setName("title");
   button.setUserLevel(EVERYONE);
   button.setUuid(UUID.randomUUID());
+  button.setConfirmation("off");
   button.setProjectKey("p1");
   button.setRepositorySlug("r1");
   return button;
  }
 
  private PrnfbButton createPrnfbButton(ButtonDTO button) {
-  PrnfbButton prnfbButton = new PrnfbButton(button.getUUID(), button.getName(), button.getUserLevel(), "p1", "r1");
+  PrnfbButton prnfbButton = new PrnfbButton(button.getUUID(), button.getName(), button.getUserLevel(), button.getConfirmation(), "p1", "r1");
   return prnfbButton;
  }
 

--- a/src/test/java/se/bjurr/prnfb/service/PrnfbRendererTest.java
+++ b/src/test/java/se/bjurr/prnfb/service/PrnfbRendererTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 
 import se.bjurr.prnfb.http.ClientKeyStore;
+import se.bjurr.prnfb.http.HttpResponse;
 import se.bjurr.prnfb.http.Invoker;
 import se.bjurr.prnfb.http.UrlInvoker;
 import se.bjurr.prnfb.listener.PrnfbPullRequestAction;
@@ -73,8 +74,10 @@ public class PrnfbRendererTest {
 
   PrnfbVariable.setInvoker(new Invoker() {
    @Override
-   public void invoke(UrlInvoker toInvoke) {
-    toInvoke.setResponseString("theResponse");
+   public HttpResponse invoke(UrlInvoker toInvoke) {
+	HttpResponse response = new HttpResponse(200, "theResponse");
+    toInvoke.setResponse(response);
+    return response;
    }
   });
  }

--- a/src/test/java/se/bjurr/prnfb/service/SettingsServiceTest.java
+++ b/src/test/java/se/bjurr/prnfb/service/SettingsServiceTest.java
@@ -94,7 +94,7 @@ public class SettingsServiceTest {
 
  @Test
  public void testThatButtonCanBeAddedUpdatedAndDeleted() {
-  PrnfbButton button1 = new PrnfbButton(null, "title", EVERYONE, "p1", "r1");
+  PrnfbButton button1 = new PrnfbButton(null, "title", EVERYONE, "off", "p1", "r1");
   assertThat(this.sut.getButtons())//
     .isEmpty();
 
@@ -102,12 +102,12 @@ public class SettingsServiceTest {
   assertThat(this.sut.getButtons())//
     .containsExactly(button1);
 
-  PrnfbButton button2 = new PrnfbButton(null, "title", EVERYONE, "p1", "r1");
+  PrnfbButton button2 = new PrnfbButton(null, "title", EVERYONE, "off", "p1", "r1");
   this.sut.addOrUpdateButton(button2);
   assertThat(this.sut.getButtons())//
     .containsExactly(button1, button2);
 
-  PrnfbButton updated = new PrnfbButton(button1.getUuid(), "title2", ADMIN, "p1", "r1");
+  PrnfbButton updated = new PrnfbButton(button1.getUuid(), "title2", ADMIN, "off", "p1", "r1");
   this.sut.addOrUpdateButton(updated);
   assertThat(this.sut.getButtons())//
     .containsExactly(button2, updated);

--- a/src/test/java/se/bjurr/prnfb/service/UserCheckServiceTest.java
+++ b/src/test/java/se/bjurr/prnfb/service/UserCheckServiceTest.java
@@ -63,9 +63,9 @@ public class UserCheckServiceTest {
   when(this.userManager.isAdmin(this.userKey))//
     .thenReturn(false);
 
-  PrnfbButton button1 = new PrnfbButton(null, "title1", ADMIN, "p1", "r1");
-  PrnfbButton button2 = new PrnfbButton(null, "title2", EVERYONE, "p1", "r1");
-  PrnfbButton button3 = new PrnfbButton(null, "title3", SYSTEM_ADMIN, "p1", "r1");
+  PrnfbButton button1 = new PrnfbButton(null, "title1", ADMIN, "off", "p1", "r1");
+  PrnfbButton button2 = new PrnfbButton(null, "title2", EVERYONE, "off", "p1", "r1");
+  PrnfbButton button3 = new PrnfbButton(null, "title3", SYSTEM_ADMIN, "off", "p1", "r1");
   List<PrnfbButton> buttons = newArrayList(button1, button2, button3);
 
   Iterable<PrnfbButton> onlyAllowed = this.sut.filterAllowed(buttons);
@@ -82,7 +82,7 @@ public class UserCheckServiceTest {
     .thenReturn(this.userKey);
   when(this.userManager.isSystemAdmin(this.userKey))//
     .thenReturn(true);
-  PrnfbButton candidate = new PrnfbButton(null, "title", ADMIN, "p1", "r1");
+  PrnfbButton candidate = new PrnfbButton(null, "title", ADMIN, "off", "p1", "r1");
   assertThat(this.sut.isAllowedUseButton(candidate))//
     .isTrue();
 


### PR DESCRIPTION
When clicking the various trigger buttons, there is no feedback to the
user that the button was clicked. Even worse, the button may have been
clicked but there was an error doing the trigger itself (either in
the PRNFB code itself or when it actually does the final HTTP call
to the backing service).

This change adds an optional confirmation dialog (with a default of it
being disabled) that will report, after the button press is complete
and we have a response from the server, whether each trigger was
successful (or if no triggers were hit).

![prnfb_setting_confirmation](https://cloud.githubusercontent.com/assets/3266/17159310/1c5dd6c8-5351-11e6-89a4-de074a117233.png)

![prnfb_dialog](https://cloud.githubusercontent.com/assets/3266/17159313/21127106-5351-11e6-8523-6b9bd7e4bbfe.png)
