### PR TITLE
fixed jenkins plugin url

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The filter text as well as the URL support variables. These are:
 
 The ${PULL_REQUEST_USER...} contains information about the user who issued the event. Who commented it, who rejected it, who approved it...
 
-You may want to use [Violation Comments to Stash plugin](https://wiki.jenkins-ci.org/display/JENKINS/Violation+Comments+to+Stash+Plugin) and/or [StashNotifier plugin](https://wiki.jenkins-ci.org/display/JENKINS/StashNotifier+Plugin) to report results back to Bitbucket.
+You may want to use [Violation Comments to Bitbucket Server plugin](https://wiki.jenkins-ci.org/display/JENKINS/Violation+Comments+to+Bitbucket+Server+Plugin) and/or [StashNotifier plugin](https://wiki.jenkins-ci.org/display/JENKINS/StashNotifier+Plugin) to report results back to Bitbucket.
 
 #### Button Forms
 


### PR DESCRIPTION
The current url in the Readme.md doesn't work. fixed it with the correct url.