### PR TITLE
Fix misspelling

### DIFF
--- a/src/main/resources/admin.vm
+++ b/src/main/resources/admin.vm
@@ -285,7 +285,7 @@
     <div class="field-group">
      <label>Name </label>
      <input class="text long-field" type="text" name="name">
-     <div class="description">Name of this trigger. This has no other function then just letting the administrator make a note of what this notification does.</div>
+     <div class="description">Name of this trigger. This has no other function than just letting the administrator make a note of what this notification does.</div>
     </div>
    </fieldset>
 


### PR DESCRIPTION
One of the first things I noticed after loading the admin panel was the erroneous use of **then** instead of **than**.  This fixes that.

Alternative phrasing, if desired:
> This has no other function **besides** letting the administrator make a note of what this notification does.