### PR TITLE
Change to force Bitbucket to perform merge

### DIFF
--- a/src/main/java/se/bjurr/prnfb/listener/PrnfbPullRequestEventListener.java
+++ b/src/main/java/se/bjurr/prnfb/listener/PrnfbPullRequestEventListener.java
@@ -119,7 +119,7 @@ public class PrnfbPullRequestEventListener {
       try {
         if (!pullRequest.isClosed()
             && pullRequestEvent.getAction().equals(PullRequestAction.RESCOPED)
-            && notification.isForceMergeOnRescope()
+            && notification.isUpdatePullRequestRefs()
             && !mergePerformed) {
           mergePerformed = true;
           try {

--- a/src/main/java/se/bjurr/prnfb/presentation/dto/NotificationDTO.java
+++ b/src/main/java/se/bjurr/prnfb/presentation/dto/NotificationDTO.java
@@ -37,6 +37,7 @@ public class NotificationDTO implements Comparable<NotificationDTO>, Restricted 
   private TRIGGER_IF_MERGE triggerIfCanMerge;
   private List<String> triggerIgnoreStateList;
   private List<String> triggers;
+  private boolean forceMergeOnRescope;
   private String url;
   private String user;
   private UUID uuid;
@@ -191,6 +192,9 @@ public class NotificationDTO implements Comparable<NotificationDTO>, Restricted 
     } else if (!triggers.equals(other.triggers)) {
       return false;
     }
+    if (forceMergeOnRescope != other.forceMergeOnRescope) {
+      return false;
+    }
     if (url == null) {
       if (other.url != null) {
         return false;
@@ -289,6 +293,10 @@ public class NotificationDTO implements Comparable<NotificationDTO>, Restricted 
     return this.triggers;
   }
 
+  public boolean isForceMergeOnRescope() {
+    return this.forceMergeOnRescope;
+  }
+
   public String getUrl() {
     return this.url;
   }
@@ -326,6 +334,7 @@ public class NotificationDTO implements Comparable<NotificationDTO>, Restricted 
     result =
         prime * result + (triggerIgnoreStateList == null ? 0 : triggerIgnoreStateList.hashCode());
     result = prime * result + (triggers == null ? 0 : triggers.hashCode());
+    result = prime * result + (forceMergeOnRescope ? 1 : 0);
     result = prime * result + (url == null ? 0 : url.hashCode());
     result = prime * result + (user == null ? 0 : user.hashCode());
     result = prime * result + (uuid == null ? 0 : uuid.hashCode());
@@ -404,6 +413,10 @@ public class NotificationDTO implements Comparable<NotificationDTO>, Restricted 
     this.triggers = triggers;
   }
 
+  public void setForceMergeOnRescope(boolean forceMergeOnRescope) {
+    this.forceMergeOnRescope = forceMergeOnRescope;
+  }
+
   public void setUrl(String url) {
     this.url = url;
   }
@@ -468,6 +481,8 @@ public class NotificationDTO implements Comparable<NotificationDTO>, Restricted 
         + triggerIgnoreStateList
         + ", triggers="
         + triggers
+        + ", forceMergeOnRescope="
+        + forceMergeOnRescope
         + ", url="
         + url
         + ", user="

--- a/src/main/java/se/bjurr/prnfb/presentation/dto/NotificationDTO.java
+++ b/src/main/java/se/bjurr/prnfb/presentation/dto/NotificationDTO.java
@@ -37,7 +37,7 @@ public class NotificationDTO implements Comparable<NotificationDTO>, Restricted 
   private TRIGGER_IF_MERGE triggerIfCanMerge;
   private List<String> triggerIgnoreStateList;
   private List<String> triggers;
-  private boolean forceMergeOnRescope;
+  private boolean updatePullRequestRefs;
   private String url;
   private String user;
   private UUID uuid;
@@ -192,7 +192,7 @@ public class NotificationDTO implements Comparable<NotificationDTO>, Restricted 
     } else if (!triggers.equals(other.triggers)) {
       return false;
     }
-    if (forceMergeOnRescope != other.forceMergeOnRescope) {
+    if (updatePullRequestRefs != other.updatePullRequestRefs) {
       return false;
     }
     if (url == null) {
@@ -293,8 +293,8 @@ public class NotificationDTO implements Comparable<NotificationDTO>, Restricted 
     return this.triggers;
   }
 
-  public boolean isForceMergeOnRescope() {
-    return this.forceMergeOnRescope;
+  public boolean isUpdatePullRequestRefs() {
+    return this.updatePullRequestRefs;
   }
 
   public String getUrl() {
@@ -334,7 +334,7 @@ public class NotificationDTO implements Comparable<NotificationDTO>, Restricted 
     result =
         prime * result + (triggerIgnoreStateList == null ? 0 : triggerIgnoreStateList.hashCode());
     result = prime * result + (triggers == null ? 0 : triggers.hashCode());
-    result = prime * result + (forceMergeOnRescope ? 1 : 0);
+    result = prime * result + (updatePullRequestRefs ? 1 : 0);
     result = prime * result + (url == null ? 0 : url.hashCode());
     result = prime * result + (user == null ? 0 : user.hashCode());
     result = prime * result + (uuid == null ? 0 : uuid.hashCode());
@@ -413,8 +413,8 @@ public class NotificationDTO implements Comparable<NotificationDTO>, Restricted 
     this.triggers = triggers;
   }
 
-  public void setForceMergeOnRescope(boolean forceMergeOnRescope) {
-    this.forceMergeOnRescope = forceMergeOnRescope;
+  public void setUpdatePullRequestRefs(boolean updatePullRequestRefs) {
+    this.updatePullRequestRefs = updatePullRequestRefs;
   }
 
   public void setUrl(String url) {
@@ -481,8 +481,8 @@ public class NotificationDTO implements Comparable<NotificationDTO>, Restricted 
         + triggerIgnoreStateList
         + ", triggers="
         + triggers
-        + ", forceMergeOnRescope="
-        + forceMergeOnRescope
+        + ", updatePullRequestRefs="
+        + updatePullRequestRefs
         + ", url="
         + url
         + ", user="

--- a/src/main/java/se/bjurr/prnfb/settings/PrnfbNotification.java
+++ b/src/main/java/se/bjurr/prnfb/settings/PrnfbNotification.java
@@ -44,7 +44,7 @@ public class PrnfbNotification implements HasUuid, Restricted {
   private final TRIGGER_IF_MERGE triggerIfCanMerge;
   private final List<PullRequestState> triggerIgnoreStateList;
   private final List<PrnfbPullRequestAction> triggers;
-  private final boolean forceMergeOnRescope;
+  private final boolean updatePullRequestRefs;
   private final String url;
   private final String user;
   private final UUID uuid;
@@ -88,7 +88,7 @@ public class PrnfbNotification implements HasUuid, Restricted {
     if (this.triggers.isEmpty()) {
       throw new ValidationException("triggers", "At least one trigger must be selected.");
     }
-    this.forceMergeOnRescope = builder.isForceMergeOnRescope();
+    this.updatePullRequestRefs = builder.isUpdatePullRequestRefs();
     this.filterString = emptyToNull(nullToEmpty(builder.getFilterString()).trim());
     this.filterRegexp = emptyToNull(nullToEmpty(builder.getFilterRegexp()).trim());
     this.name = firstNonNull(emptyToNull(nullToEmpty(builder.getName()).trim()), DEFAULT_NAME);
@@ -231,7 +231,7 @@ public class PrnfbNotification implements HasUuid, Restricted {
     } else if (!triggers.equals(other.triggers)) {
       return false;
     }
-    if (forceMergeOnRescope != other.forceMergeOnRescope) {
+    if (updatePullRequestRefs != other.updatePullRequestRefs) {
       return false;
     }
     if (url == null) {
@@ -336,8 +336,8 @@ public class PrnfbNotification implements HasUuid, Restricted {
     return this.triggers;
   }
 
-  public boolean isForceMergeOnRescope() {
-    return this.forceMergeOnRescope;
+  public boolean isUpdatePullRequestRefs() {
+    return this.updatePullRequestRefs;
   }
 
   public String getUrl() {
@@ -377,7 +377,7 @@ public class PrnfbNotification implements HasUuid, Restricted {
     result =
         prime * result + (triggerIgnoreStateList == null ? 0 : triggerIgnoreStateList.hashCode());
     result = prime * result + (triggers == null ? 0 : triggers.hashCode());
-    result = prime * result + (forceMergeOnRescope ? 1 : 0);
+    result = prime * result + (updatePullRequestRefs ? 1 : 0);
     result = prime * result + (url == null ? 0 : url.hashCode());
     result = prime * result + (user == null ? 0 : user.hashCode());
     result = prime * result + (uuid == null ? 0 : uuid.hashCode());
@@ -422,8 +422,8 @@ public class PrnfbNotification implements HasUuid, Restricted {
         + triggerIgnoreStateList
         + ", triggers="
         + triggers
-        + ", forceMergeOnRescope="
-        + forceMergeOnRescope
+        + ", updatePullRequestRefs="
+        + updatePullRequestRefs
         + ", url="
         + url
         + ", user="

--- a/src/main/java/se/bjurr/prnfb/settings/PrnfbNotification.java
+++ b/src/main/java/se/bjurr/prnfb/settings/PrnfbNotification.java
@@ -44,6 +44,7 @@ public class PrnfbNotification implements HasUuid, Restricted {
   private final TRIGGER_IF_MERGE triggerIfCanMerge;
   private final List<PullRequestState> triggerIgnoreStateList;
   private final List<PrnfbPullRequestAction> triggers;
+  private final boolean forceMergeOnRescope;
   private final String url;
   private final String user;
   private final UUID uuid;
@@ -87,6 +88,7 @@ public class PrnfbNotification implements HasUuid, Restricted {
     if (this.triggers.isEmpty()) {
       throw new ValidationException("triggers", "At least one trigger must be selected.");
     }
+    this.forceMergeOnRescope = builder.isForceMergeOnRescope();
     this.filterString = emptyToNull(nullToEmpty(builder.getFilterString()).trim());
     this.filterRegexp = emptyToNull(nullToEmpty(builder.getFilterRegexp()).trim());
     this.name = firstNonNull(emptyToNull(nullToEmpty(builder.getName()).trim()), DEFAULT_NAME);
@@ -229,6 +231,9 @@ public class PrnfbNotification implements HasUuid, Restricted {
     } else if (!triggers.equals(other.triggers)) {
       return false;
     }
+    if (forceMergeOnRescope != other.forceMergeOnRescope) {
+      return false;
+    }
     if (url == null) {
       if (other.url != null) {
         return false;
@@ -331,6 +336,10 @@ public class PrnfbNotification implements HasUuid, Restricted {
     return this.triggers;
   }
 
+  public boolean isForceMergeOnRescope() {
+    return this.forceMergeOnRescope;
+  }
+
   public String getUrl() {
     return this.url;
   }
@@ -368,6 +377,7 @@ public class PrnfbNotification implements HasUuid, Restricted {
     result =
         prime * result + (triggerIgnoreStateList == null ? 0 : triggerIgnoreStateList.hashCode());
     result = prime * result + (triggers == null ? 0 : triggers.hashCode());
+    result = prime * result + (forceMergeOnRescope ? 1 : 0);
     result = prime * result + (url == null ? 0 : url.hashCode());
     result = prime * result + (user == null ? 0 : user.hashCode());
     result = prime * result + (uuid == null ? 0 : uuid.hashCode());
@@ -412,6 +422,8 @@ public class PrnfbNotification implements HasUuid, Restricted {
         + triggerIgnoreStateList
         + ", triggers="
         + triggers
+        + ", forceMergeOnRescope="
+        + forceMergeOnRescope
         + ", url="
         + url
         + ", user="

--- a/src/main/java/se/bjurr/prnfb/settings/PrnfbNotificationBuilder.java
+++ b/src/main/java/se/bjurr/prnfb/settings/PrnfbNotificationBuilder.java
@@ -39,7 +39,7 @@ public class PrnfbNotificationBuilder {
       TRIGGER_IF_MERGE triggerIfCanMerge,
       List<PullRequestState> triggerIgnoreStateList,
       List<PrnfbPullRequestAction> triggers,
-      boolean forceMergeOnRescope,
+      boolean updatePullRequestRefs,
       String url,
       String user,
       UUID uuid,
@@ -63,7 +63,7 @@ public class PrnfbNotificationBuilder {
     this.triggerIfCanMerge = triggerIfCanMerge;
     this.triggerIgnoreStateList = triggerIgnoreStateList;
     this.triggers = triggers;
-    this.forceMergeOnRescope = forceMergeOnRescope;
+    this.updatePullRequestRefs = updatePullRequestRefs;
     this.url = url;
     this.user = user;
     this.uuid = uuid;
@@ -77,7 +77,7 @@ public class PrnfbNotificationBuilder {
     b.uuid = from.getUuid();
     b.password = from.getPassword().orNull();
     b.triggers = from.getTriggers();
-    b.forceMergeOnRescope = from.isForceMergeOnRescope();
+    b.updatePullRequestRefs = from.isUpdatePullRequestRefs();
     b.url = from.getUrl();
     b.user = from.getUser().orNull();
     b.filterRegexp = from.getFilterRegexp().orNull();
@@ -119,7 +119,7 @@ public class PrnfbNotificationBuilder {
   private TRIGGER_IF_MERGE triggerIfCanMerge;
   private List<PullRequestState> triggerIgnoreStateList = newArrayList();
   private List<PrnfbPullRequestAction> triggers = newArrayList();
-  private boolean forceMergeOnRescope;
+  private boolean updatePullRequestRefs;
   private String url;
   private String user;
   private UUID uuid;
@@ -214,8 +214,8 @@ public class PrnfbNotificationBuilder {
     return this.triggers;
   }
 
-  public boolean isForceMergeOnRescope() {
-    return this.forceMergeOnRescope;
+  public boolean isUpdatePullRequestRefs() {
+    return this.updatePullRequestRefs;
   }
 
   public String getUrl() {
@@ -250,8 +250,8 @@ public class PrnfbNotificationBuilder {
     return this;
   }
 
-  public PrnfbNotificationBuilder setForceMergeOnRescope(boolean forceMergeOnRescope) {
-    this.forceMergeOnRescope = forceMergeOnRescope;
+  public PrnfbNotificationBuilder setUpdatePullRequestRefs(boolean updatePullRequestRefs) {
+    this.updatePullRequestRefs = updatePullRequestRefs;
     return this;
   }
 
@@ -335,8 +335,8 @@ public class PrnfbNotificationBuilder {
     return this;
   }
 
-  public PrnfbNotificationBuilder withForceMergeOnRescope(boolean forceMergeOnRescope) {
-    this.forceMergeOnRescope = forceMergeOnRescope;
+  public PrnfbNotificationBuilder withUpdatePullRequestRefs(boolean updatePullRequestRefs) {
+    this.updatePullRequestRefs = updatePullRequestRefs;
     return this;
   }
 

--- a/src/main/java/se/bjurr/prnfb/settings/PrnfbNotificationBuilder.java
+++ b/src/main/java/se/bjurr/prnfb/settings/PrnfbNotificationBuilder.java
@@ -39,6 +39,7 @@ public class PrnfbNotificationBuilder {
       TRIGGER_IF_MERGE triggerIfCanMerge,
       List<PullRequestState> triggerIgnoreStateList,
       List<PrnfbPullRequestAction> triggers,
+      boolean forceMergeOnRescope,
       String url,
       String user,
       UUID uuid,
@@ -62,6 +63,7 @@ public class PrnfbNotificationBuilder {
     this.triggerIfCanMerge = triggerIfCanMerge;
     this.triggerIgnoreStateList = triggerIgnoreStateList;
     this.triggers = triggers;
+    this.forceMergeOnRescope = forceMergeOnRescope;
     this.url = url;
     this.user = user;
     this.uuid = uuid;
@@ -75,6 +77,7 @@ public class PrnfbNotificationBuilder {
     b.uuid = from.getUuid();
     b.password = from.getPassword().orNull();
     b.triggers = from.getTriggers();
+    b.forceMergeOnRescope = from.isForceMergeOnRescope();
     b.url = from.getUrl();
     b.user = from.getUser().orNull();
     b.filterRegexp = from.getFilterRegexp().orNull();
@@ -116,6 +119,7 @@ public class PrnfbNotificationBuilder {
   private TRIGGER_IF_MERGE triggerIfCanMerge;
   private List<PullRequestState> triggerIgnoreStateList = newArrayList();
   private List<PrnfbPullRequestAction> triggers = newArrayList();
+  private boolean forceMergeOnRescope;
   private String url;
   private String user;
   private UUID uuid;
@@ -210,6 +214,10 @@ public class PrnfbNotificationBuilder {
     return this.triggers;
   }
 
+  public boolean isForceMergeOnRescope() {
+    return this.forceMergeOnRescope;
+  }
+
   public String getUrl() {
     return this.url;
   }
@@ -239,6 +247,11 @@ public class PrnfbNotificationBuilder {
 
   public PrnfbNotificationBuilder setTriggers(List<PrnfbPullRequestAction> triggers) {
     this.triggers = triggers;
+    return this;
+  }
+
+  public PrnfbNotificationBuilder setForceMergeOnRescope(boolean forceMergeOnRescope) {
+    this.forceMergeOnRescope = forceMergeOnRescope;
     return this;
   }
 
@@ -319,6 +332,11 @@ public class PrnfbNotificationBuilder {
 
   public PrnfbNotificationBuilder withTrigger(PrnfbPullRequestAction trigger) {
     this.triggers.add(trigger);
+    return this;
+  }
+
+  public PrnfbNotificationBuilder withForceMergeOnRescope(boolean forceMergeOnRescope) {
+    this.forceMergeOnRescope = forceMergeOnRescope;
     return this;
   }
 

--- a/src/main/java/se/bjurr/prnfb/transformer/NotificationTransformer.java
+++ b/src/main/java/se/bjurr/prnfb/transformer/NotificationTransformer.java
@@ -39,6 +39,7 @@ public class NotificationTransformer {
     to.setTriggerIfCanMerge(from.getTriggerIfCanMerge());
     to.setTriggerIgnoreStateList(toPullRequestStateStrings(from.getTriggerIgnoreStateList()));
     to.setTriggers(toStrings(from.getTriggers()));
+    to.setForceMergeOnRescope(from.isForceMergeOnRescope());
     to.setUrl(from.getUrl());
     to.setUser(UNCHANGED);
     to.setPassword(UNCHANGED);
@@ -75,6 +76,7 @@ public class NotificationTransformer {
         .withProxySchema(from.getProxySchema()) //
         .withProxyUser(from.getProxyUser()) //
         .setTriggers(toPrnfbPullRequestActions(from.getTriggers())) //
+        .withForceMergeOnRescope(from.isForceMergeOnRescope()) //
         .withTriggerIfCanMerge(from.getTriggerIfCanMerge()) //
         .setTriggerIgnoreState(toPullRequestStates(from.getTriggerIgnoreStateList())) //
         .withUrl(from.getUrl()) //

--- a/src/main/java/se/bjurr/prnfb/transformer/NotificationTransformer.java
+++ b/src/main/java/se/bjurr/prnfb/transformer/NotificationTransformer.java
@@ -39,7 +39,7 @@ public class NotificationTransformer {
     to.setTriggerIfCanMerge(from.getTriggerIfCanMerge());
     to.setTriggerIgnoreStateList(toPullRequestStateStrings(from.getTriggerIgnoreStateList()));
     to.setTriggers(toStrings(from.getTriggers()));
-    to.setForceMergeOnRescope(from.isForceMergeOnRescope());
+    to.setUpdatePullRequestRefs(from.isUpdatePullRequestRefs());
     to.setUrl(from.getUrl());
     to.setUser(UNCHANGED);
     to.setPassword(UNCHANGED);
@@ -76,7 +76,7 @@ public class NotificationTransformer {
         .withProxySchema(from.getProxySchema()) //
         .withProxyUser(from.getProxyUser()) //
         .setTriggers(toPrnfbPullRequestActions(from.getTriggers())) //
-        .withForceMergeOnRescope(from.isForceMergeOnRescope()) //
+        .withUpdatePullRequestRefs(from.isUpdatePullRequestRefs()) //
         .withTriggerIfCanMerge(from.getTriggerIfCanMerge()) //
         .setTriggerIgnoreState(toPullRequestStates(from.getTriggerIgnoreStateList())) //
         .withUrl(from.getUrl()) //

--- a/src/main/resources/admin.vm
+++ b/src/main/resources/admin.vm
@@ -460,6 +460,15 @@
     </div>
    </fieldset>
 
+  <fieldset class="group">
+   <legend>
+    <span>Force Merge on Rescope</span>
+   </legend>
+   <div class="checkbox">
+    <input class="checkbox" type="checkbox" name="forceMergeOnRescope" value="true">
+   </div>
+  </fieldset>
+
    <h4>Injection URL</h4>
    <p>Optional configuration for retrieving a value from a pre URL invocation. A Jenkins installation may require the value of <i>http://JENKINS/crumbIssuer/api/xml?xpath=//crumb/text()</i> to be used in a request.</p>
    <fieldset class="group">

--- a/src/main/resources/admin.vm
+++ b/src/main/resources/admin.vm
@@ -462,10 +462,13 @@
 
   <fieldset class="group">
    <legend>
-    <span>Force Merge on Rescope</span>
+    <span>Update Pull Request References</span>
    </legend>
    <div class="checkbox">
-    <input class="checkbox" type="checkbox" name="forceMergeOnRescope" value="true">
+    <input class="checkbox" type="checkbox" name="updatePullRequestRefs" value="true">&nbsp;
+   </div>
+   <div class="description">
+     Will update refs/pull-requests/{id}/from and refs/pull-requests/{id}/merge references in Git when Pull Request is rescoped.
    </div>
   </fieldset>
 

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -25,6 +25,7 @@
  <component-import key="projectService" interface="com.atlassian.bitbucket.project.ProjectService" />
  <component-import key="executorService" interface="java.util.concurrent.ExecutorService" />
  <component-import key="permissionService" interface="com.atlassian.bitbucket.permission.PermissionService" />
+ <component-import key="scmService" interface="com.atlassian.bitbucket.scm.ScmService" />
 
  <rest key="rest" path="/prnfb-admin" version="1.0">
   <description>Provides REST resources for the admin UI.</description>

--- a/src/test/java/se/bjurr/prnfb/listener/PrnfbPullRequestEventListenerTest.java
+++ b/src/test/java/se/bjurr/prnfb/listener/PrnfbPullRequestEventListenerTest.java
@@ -23,6 +23,7 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
+import com.atlassian.bitbucket.scm.ScmService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -70,6 +71,7 @@ public class PrnfbPullRequestEventListenerTest {
   @Mock private PullRequestService pullRequestService;
   @Mock private PrnfbRenderer renderer;
   @Mock private SettingsService settingsService;
+  @Mock private ScmService scmService;
   private Boolean shouldAcceptAnyCertificate;
   private PrnfbPullRequestEventListener sut;
   @Mock private PullRequestRef toRef;
@@ -101,7 +103,8 @@ public class PrnfbPullRequestEventListenerTest {
             pullRequestService,
             executorService,
             settingsService,
-            securityService);
+            securityService,
+            scmService);
     setInvoker(
         new Invoker() {
           @Override

--- a/src/test/java/se/bjurr/prnfb/listener/PrnfbPullRequestEventListenerTest.java
+++ b/src/test/java/se/bjurr/prnfb/listener/PrnfbPullRequestEventListenerTest.java
@@ -20,11 +20,9 @@ import static se.bjurr.prnfb.settings.TRIGGER_IF_MERGE.NOT_CONFLICTING;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-import com.atlassian.bitbucket.event.pull.PullRequestRescopedEvent;
 import com.atlassian.bitbucket.scm.Command;
 import com.atlassian.bitbucket.scm.ScmService;
 import com.atlassian.bitbucket.scm.pull.ScmPullRequestCommandFactory;
@@ -177,7 +175,7 @@ public class PrnfbPullRequestEventListenerTest {
         prnfbNotificationBuilder(notification1) //
             .withUrl("http://not2.com/") //
             .withTrigger(PrnfbPullRequestAction.RESCOPED_FROM) //
-            .withForceMergeOnRescope(true) //
+            .withUpdatePullRequestRefs(true) //
             .build();
     List<PrnfbNotification> notifications =
         newArrayList(notification1, notification2, notification3);
@@ -511,7 +509,8 @@ public class PrnfbPullRequestEventListenerTest {
   }
 
   @Test
-  public void testThatTryMergeIsCalledWhenForceMergeOnRescopeEnabled() throws ValidationException {
+  public void testThatTryMergeIsCalledWhenUpdatePullRequestRefsEnabled()
+      throws ValidationException {
     when(scmService.getPullRequestCommandFactory(any(PullRequest.class)))
         .thenReturn(pullRequestCommandFactory);
     when(pullRequestCommandFactory.tryMerge(any(PullRequest.class))).thenReturn(pullRequestCommand);


### PR DESCRIPTION
As per its current design, when you push updates to a pull request,
Bitbucket does not try and merge the updates until (usually) the user
visits the Pull Request UI page.

This means that if you notify, say, Jenkins to try and build your update
PR, it will in fact only build the last version that has been looked at
within the UI.

This change causes Bitbucket to try and do the merge prior to notifying
in order to have updated the Git references with the latest commits for
the external system to fetch and act on.

Note that this PR is possibly not ready to merge as is as I have not written any unit test yet (any hints on best way to test this change would be most welcome), plus there may be cases when not to try and do the tryMerge (so, again, hints on whether there's any cases to consider gladly received).