### PR TITLE
inject additional leading spaces so markdown list elements nest/indent as intended

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ The original use case was to trigger Jenkins jobs to build and verify pull reque
 The Pull Request Notifier for Bitbucket Server can:
 
 * Invoke any URL, or set of URL:s, when a pull request event happens.
- * With variables available to add necessary parameters.
- * HTTP POST, PUT, GET and DELETE. POST and PUT also supports rendered post content. 
+  * With variables available to add necessary parameters.
+  * HTTP POST, PUT, GET and DELETE. POST and PUT also supports rendered post content.
 * Be configured to trigger on any [pull request event](https://developer.atlassian.com/static/javadoc/stash.old-perms-pre-feb4/2.0.1/api/reference/com/atlassian/stash/event/pull/package-summary.html). Including extended events:
- * RESCOPED_FROM, when source branch change
- * RESCOPED_TO, when target branch change
- * BUTTON_TRIGGER, when trigger button in pull request view is pressed
+  * RESCOPED_FROM, when source branch change
+  * RESCOPED_TO, when target branch change
+  * BUTTON_TRIGGER, when trigger button in pull request view is pressed
 * Can invoke CSRF protected systems, using the ${INJECTION_URL_VALUE} variable. How to to that with Jenkins is described below.
 * Be configured to only trigger if the pull request matches a filter. A filter text is constructed with any combination of the variables and then a regexp is constructed to match that text.
 * Add buttons to pull request view in Bitbucket Server. And map those buttons to URL invocations. This can be done by setting the filter string to ${BUTTON_TRIGGER_TITLE} and the filter regexp to title of button.
- * Buttons can have forms associated with them, and then submit the form data using the ${BUTTON_FORM_DATA} variable.
+  * Buttons can have forms associated with them, and then submit the form data using the ${BUTTON_FORM_DATA} variable.
 * Authenticate with HTTP basic authentication.
 * Optionally allow any SSL certificate.
 * Use custom SSL key store, type and password.
@@ -29,13 +29,13 @@ The Pull Request Notifier for Bitbucket Server can:
 * Can optionally use proxy to connect
 * Can let users and/or admins do configuration. Or restrict configuration to just system admins. A user will have to browse to the configuration page at `http://domain/bitbucket/plugins/servlet/prnfb/admin`.
 * Can enable trigger
- * If PR has, or has no, conflicts
- * Only if PR has conflicts
- * Only if PR has no conflicts
+  * If PR has, or has no, conflicts
+  * Only if PR has conflicts
+  * Only if PR has no conflicts
 * Nice configuration GUI.
- * Global at */bitbucket/plugins/servlet/prnfb/admin*
- * Project level at */bitbucket/plugins/servlet/prnfb/admin/PROJECT_1*
- * Repo level at */bitbucket/plugins/servlet/prnfb/admin/PROJECT_1/rep_1*
+  * Global at */bitbucket/plugins/servlet/prnfb/admin*
+  * Project level at */bitbucket/plugins/servlet/prnfb/admin/PROJECT_1*
+  * Repo level at */bitbucket/plugins/servlet/prnfb/admin/PROJECT_1/rep_1*
 
 The plugin has its own implementation to create the RESCOPED_FROM and RESCOPED_TO events. RESCOPED is transformed to RESCOPED_TO if target branch changed, RESCOPED_FROM if source branch, or both, changed.
 

--- a/README_jenkins.md
+++ b/README_jenkins.md
@@ -4,7 +4,7 @@ Parameterized Jenkins jobs can be triggered remotely by invoking a URL. How you 
 The job that you want to trigger must have:
  * *This build is parameterized* checkbox checked.
  * *Trigger builds remotely* checkbox checked.
-  * You may, or may not, use a token here.
+   * You may, or may not, use a token here.
 
 There is a full job-dsl for this in [here](https://github.com/jenkinsci/violation-comments-to-stash-plugin).
 
@@ -33,8 +33,8 @@ If you need ***authentication***, add your username and password in *Basic authe
 
 If you are using a ***CSRF*** protection in Jenkins, you can use the **Injection URL** feature.
  * Set **Injection URL** field to `http://JENKINS_HOSTNAME/crumbIssuer/api/xml?xpath=//crumb/text()`.
-  * You may get an error like *primitive XPath result sets forbidden; implement jenkins.security.SecureRequester*. If so, you can set Injection URL to `http://JENKINS/crumbIssuer/api/xml?xpath=//crumb` in combination with regular expression `<crumb>([^<]*)</crumb>`.
-  * A third option is to checkout [this](https://wiki.jenkins-ci.org/display/JENKINS/Secure+Requester+Whitelist+Plugin) Jenkins plugin.
+   * You may get an error like *primitive XPath result sets forbidden; implement jenkins.security.SecureRequester*. If so, you can set Injection URL to `http://JENKINS/crumbIssuer/api/xml?xpath=//crumb` in combination with regular expression `<crumb>([^<]*)</crumb>`.
+   * A third option is to checkout [this](https://wiki.jenkins-ci.org/display/JENKINS/Secure+Requester+Whitelist+Plugin) Jenkins plugin.
  * In the headers section, set header **Jenkins-Crumb** with value **${INJECTION_URL_VALUE}**. The `Jenkins-Crumb` header name was previously just `.crumb`, use whatever the `curl` command responded with above.
 
 You may trigger the build with `GET` or `POST`.


### PR DESCRIPTION
Change is markdown-document-format only; sole "testing" was to view rendering of changed markdown files in forked repo to confirm desired effect was achieved.