### PR TITLE
uses jQuery.remove() for greater protability

### DIFF
--- a/src/main/resources/pr-triggerbutton.js
+++ b/src/main/resources/pr-triggerbutton.js
@@ -13,7 +13,7 @@ define('plugin/prnfb/pr-triggerbutton', [
   var buttonText = $(auiButton).text().trim();
   if (buttonText === '' || buttonText === 'pr-triggerbutton') {
    //An empty button is added by 'client-web-item' in atlassian-plugin.xml
-   auiButton.remove();
+   $(auiButton).remove();
   }
  });
 


### PR DESCRIPTION
Per #263 

Internet Explorer's HTMLButtonElement doesn't support a .remove() function, but jQuery can remove the element across browsers.

Tested this in both IE 11 and Chrome 62.0.3202.62 (64-bit). No JavaScript exceptions and buttons render correctly in both browsers.