### PR TITLE
uses jQuery.remove() for greater protability

### DIFF
--- a/src/main/resources/pr-triggerbutton.js
+++ b/src/main/resources/pr-triggerbutton.js
@@ -13,7 +13,7 @@ define('plugin/prnfb/pr-triggerbutton', [
   var buttonText = $(auiButton).text().trim();
   if (buttonText === '' || buttonText === 'pr-triggerbutton') {
    //An empty button is added by 'client-web-item' in atlassian-plugin.xml
-   auiButton.remove();
+   $(auiButton).remove();
   }
  });
 


### PR DESCRIPTION
Internet Explorer's HTMLButtonElement doesn't support a .remove() function, but jQuery can remove the element across browsers.

This was already merged to master but I was hoping backport to 2.x for a new release in order to support Server 4.12.