### PR TITLE
Fix visible "pr-triggerbutton"

### DIFF
--- a/src/main/resources/pr-triggerbutton.js
+++ b/src/main/resources/pr-triggerbutton.js
@@ -295,6 +295,8 @@ define('plugin/prnfb/pr-triggerbutton', [
  });
 });
 
-AJS.$(document).ready(function() {
- require('plugin/prnfb/pr-triggerbutton');
+require(['bitbucket/util/events'], function(events) { 
+ events.on('bitbucket.internal.feature.repositories.recent.loaded', function() {
+  require('plugin/prnfb/pr-triggerbutton');
+ })
 });


### PR DESCRIPTION
"pr-triggerbutton" button wouldn't get removed if the pull request wasn't in OPEN state.