### PR TITLE
Update Azure Pipelines Sample to set branch of pull request

### DIFF
--- a/README_azurepiplines.md
+++ b/README_azurepiplines.md
@@ -13,21 +13,19 @@ Here is how to integrate with Azure Pipelines (VSTS).
         "reason": "pullRequest",
         "sourceBranch": "${PULL_REQUEST_FROM_ID}",
         "sourceVersion": "${PULL_REQUEST_FROM_HASH}",
-        "properties": {
-            "pullRequest": {
-                "url": "${PULL_REQUEST_URL}",
-                "user": "${PULL_REQUEST_USER_EMAIL_ADDRESS}",
-                "title": "${PULL_REQUEST_TITLE}",
-                "version": "${PULL_REQUEST_VERSION}",
-                "author": "${PULL_REQUEST_AUTHOR_EMAIL}",
-                "reviewers": "${PULL_REQUEST_REVIEWERS_EMAIL}"
-            }
+        "triggerInfo": {
+            "url": "${PULL_REQUEST_URL}",
+            "user": "${PULL_REQUEST_USER_EMAIL_ADDRESS}",
+            "title": "${PULL_REQUEST_TITLE}",
+            "version": "${PULL_REQUEST_VERSION}",
+            "author": "${PULL_REQUEST_AUTHOR_EMAIL}",
+            "reviewers": "${PULL_REQUEST_REVIEWERS_EMAIL}"
         }
 }
 ```
 * Encode post content as JSON
 * In **Headers** add "Content-Type" with value "application/json"
 
-Additional data can be sent in the post. See [Azure API Docs](https://docs.microsoft.com/en-us/rest/api/azure/devops/build/Builds/Queue?view=azure-devops-rest-5.0) for more info. The properties collection is not shown in the VSTS UI, but is returned in API calls.
+Additional data can be sent in the post. See [Azure API Docs](https://docs.microsoft.com/en-us/rest/api/azure/devops/build/Builds/Queue?view=azure-devops-rest-5.0) for more info. The triggerInfo collection is not shown in the VSTS UI, but is returned in API calls.
 
 It's a good idea to use a personal access token from a service principal for authentication. The queued builds will all state that they were triggered by the owner of the token.

--- a/README_azurepiplines.md
+++ b/README_azurepiplines.md
@@ -10,9 +10,24 @@ Here is how to integrate with Azure Pipelines (VSTS).
         "definition": {
             "id": <build definitionId from url>
         }
+        "reason": "pullRequest",
+        "sourceBranch": "${PULL_REQUEST_FROM_ID}",
+        "sourceVersion": "${PULL_REQUEST_FROM_HASH}",
+        "properties": {
+            "pullRequest": {
+                "url": "${PULL_REQUEST_URL}",
+                "user": "${PULL_REQUEST_USER_EMAIL_ADDRESS}",
+                "title": "${PULL_REQUEST_TITLE}",
+                "version": "${PULL_REQUEST_VERSION}",
+                "author": "${PULL_REQUEST_AUTHOR_EMAIL}",
+                "reviewers": "${PULL_REQUEST_REVIEWERS_EMAIL}"
+            }
+        }
 }
 ```
 * Encode post content as JSON
 * In **Headers** add "Content-Type" with value "application/json"
 
-Additional data can be sent in the post. See [Azure API Docs](https://docs.microsoft.com/en-us/rest/api/azure/devops/build/Builds/Queue?view=azure-devops-rest-5.0) for more info. The build history will state 'Manual build for <owner of personal access token>' for each build triggered by this method.
+Additional data can be sent in the post. See [Azure API Docs](https://docs.microsoft.com/en-us/rest/api/azure/devops/build/Builds/Queue?view=azure-devops-rest-5.0) for more info. The properties collection is not shown in the VSTS UI, but is returned in API calls.
+
+It's a good idea to use a personal access token from a service principal for authentication. The queued builds will all state that they were triggered by the owner of the token.


### PR DESCRIPTION
Filled out the sample trigger more completely. 

`sourceBranch` and `sourceVersion` are important for setting the build branch in VSTS.
`reason` changes the build history description from 'Manual build for X' to 'Pull request build for X'.
`triggerInfo` allows arbitrary key value pairs that might be useful in additional automation later.